### PR TITLE
Additional errors from avalara response are not included and handled

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -95,7 +95,6 @@ module Spree
       rescue => error
         logger.debug 'Avatax Commit Failed!'
         logger.debug error.to_s
-        raise Avalara::Error.new error.to_s
       end
 
     end

--- a/app/models/spree/tax_rate_decorator.rb
+++ b/app/models/spree/tax_rate_decorator.rb
@@ -6,7 +6,7 @@ module Spree
       label = create_label
       if order.tax_zone.name =~ /Avalara/
         order.adjustments.tax.delete_all
-        order.commit_avatax_invoice('SalesOrder') if order.ship_address
+        order.commit_avatax_invoice('SalesOrder') if order.valid_bill_ship_address?
       else
         amount = compute_amount(item)
         return if amount == 0


### PR DESCRIPTION
When the Avalara Webservice returns a status code error(500) the errors is not
well handled and just an exception is raised, and sometimes when the status code
is 200 but the street has some validation errors those errors are not injected
into the active records object for that address.
With the aim of managing those errors correctly some methods are added
in order to inject the errors into the right active record object and avoiding
the exception stopping de program flow execution.
